### PR TITLE
Add options.tagger to derive custom tags for metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,14 @@ The ``options`` object accepts the following fields:
     <td>Tags to add to influxdb measurements</td>
   </tr>
   <tr>
+    <th>tagger</th>
+    <td>function</td>
+    <td><code>none</code></td>
+    <td>Function invoked with the metric key and expected to return the tags for
+    it in the form <code>{tag1: value1, tag2: value2, ...}</code>
+        </td>
+  </tr>
+  <tr>
     <th>precision</th>
     <td>string</td>
     <td><code>n</code></td>

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -18,6 +18,7 @@ var Reporter = function(options) {
   this.tags = options.tags || {};
   this.skipIdleMetrics = options.skipIdleMetrics || false;
   this.previousValues = {};
+  this.tagger = options.tagger || function () { return {}; };
 }
 
 function delta(reporter, name, value) {
@@ -99,7 +100,8 @@ Reporter.prototype.report = function(buffer) {
         default:
           continue;
       }
-      this._influx.addPoint(key, this.tags, timestamp, fields);
+      var tags = Object.assign(this.tagger(key), this.tags);
+      this._influx.addPoint(key, tags, timestamp, fields);
     }
   }
   if (!buffer) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metrics-influxdb",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "InfluxDB backend integration for metrics",
   "main": "lib/reporter.js",
   "scripts": {

--- a/test/reporter-test.js
+++ b/test/reporter-test.js
@@ -34,11 +34,28 @@ describe('reporter', function() {
     var secondCounter = new metrics.Counter();
     firstCounter.inc();
     reporter.addMetric('test.one.counter', firstCounter);
-    reporter.addMetric('test.two.counter', secondCounter);    
+    reporter.addMetric('test.two.counter', secondCounter);
     reporter.report(true);
     expect(reporter._influx.points).to.have.length(2);
     expect(reporter._influx.points[0]).to.have.string('test.one.counter count=1i');
     expect(reporter._influx.points[1]).to.have.string('test.two.counter count=0i');
+    done();
+  });
+
+  it('should add tags', function(done){
+    var reporter = new Reporter({
+        protocol: 'udp',
+        tags: { tag0: "default" },
+        tagger: function (key) {
+            var dimensions = key.split(".");
+            return { dim1: dimensions[0], dim2: dimensions[1] };
+        }
+    });
+    expect(reporter).to.be.defined;
+    reporter.addMetric('my.counter', new metrics.Counter());
+    reporter.report(true);
+    expect(reporter._influx.points).to.have.length(1);
+    expect(reporter._influx.points[0]).to.have.string('my.counter,dim1=my,dim2=counter,tag0=default count=0i');
     done();
   });
 


### PR DESCRIPTION
Enable the user to define what tags to assign to a metric based on its key. It can be used f.ex. to replicate the [filters and tag templates]https://github.com/influxdata/influxdb/blob/master/services/graphite/README.md#parsing-metrics) used to create tags from graphite metrics. Providing a function for this offers the most flexibility.
