### PR TITLE
Enable users to pass callback for http/udp errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,12 @@ The ``options`` object accepts the following fields:
     <td><code>false</code></td>
     <td>Suppress sending of metrics if there has been no new updates from previous report</td>
   </tr>
+  <tr>
+    <th>callback</th>
+    <td>function</td>
+    <td><code>none</code></td>
+    <td>A standard Node callback invoked with the result of the InfluxDB call (nothing or an `Error`).</td>
+  </tr>
 </table>
 
 The <code>udp</code> protocol accepts the following additional options:

--- a/lib/http_client.js
+++ b/lib/http_client.js
@@ -19,6 +19,7 @@ var HTTPClient = function(options) {
   this.password = options.password;
   this.precision = options.precision;
   this.timeout = options.httpTimeout || 200;
+  this.callback = options.callback;
   if (options.consistency) {
     if (['one','quorum','all','any'].indexOf(options.consistency) < 0) {
       throw new Error('Consistency must be one of [one,quorum,all,any]');
@@ -28,6 +29,7 @@ var HTTPClient = function(options) {
 }
 
 HTTPClient.prototype.send = function(buf, offset, length, callback) {
+  callback = callback || this.callback;
   var self = this;
   var qs = '?db=' + this.database;
   if (this.username) { qs += '&u=' + this.username; }
@@ -49,42 +51,35 @@ HTTPClient.prototype.send = function(buf, offset, length, callback) {
     }
     switch (res.statusCode) {
       case 200:
-        var data = '';
-        res.on('data', function (chunk) { data += chunk; });
-        res.on('end', function() {
-          if (typeof(callback) == 'function') {
-            callback(new Error("Problem with request: " + data));
-          } else {
-            console.log("Problem with request: " + data);
-          }
-        });
+        handleSendError(res, "Problem with request", callback);
         break;
       case 401:
-        if (typeof(callback) == 'function') {
-          callback(new Error("Unauthorized user"));
-        } else {
-          console.log("Unauthorized user");
-        }
+        handleSendError(res, "Unauthorized user", callback);
         return;
       case 400:
-        if (typeof(callback) == 'function') {
-          callback(new Error("Invalid syntax"));
-        } else {
-          console.log("Invalid syntax");
-        }
+        handleSendError(res, "Invalid syntax in: " + buf.slice(offset, length), callback);
         return;
       default:
-        if (typeof(callback) == 'function') {
-          callback(new Error("Unknown response status: " + res.statusCode));
-        } else {
-          console.log("Unknown response status: " + res.statusCode);
-        }
+        handleSendError(res, "Unknown response status: " + res.statusCode, callback);
         return;
     }
   });
   req.on('error', function(e) { if (typeof(callback) == 'function') { callback(e); } else { console.log(e); } });
   req.write(buf.slice(offset, length));
   req.end();
+}
+
+function handleSendError(res, errorMessage, callback) {
+    var data = '';
+    res.on('data', function (chunk) { data += chunk; });
+
+    res.on('end', function() {
+    if (typeof(callback) == 'function') {
+        callback(new Error(errorMessage + " Response: " + data));
+    } else {
+        console.log(errorMessage  + " Response: " + data);
+    }
+  });
 }
 
 HTTPClient.prototype.writePoints = function(batches) {

--- a/lib/udp_client.js
+++ b/lib/udp_client.js
@@ -16,9 +16,11 @@ var UDPClient = function(options) {
   this.host = options.host || '127.0.0.1';
   this.port = options.port || 8089;
   this.maxPacketSize = options.maxPacketSize || 1024;
+  this.callback = options.callback;
 }
 
 UDPClient.prototype.send = function(buf, offset, length, callback) {
+  callback = callback || this.callback;
   var self = this;
   dns.lookup(this.host, function(err, address, family) {
     if (err) { if (typeof(callback) == 'function') {  callback(err); } else { console.log(e); }; return; }


### PR DESCRIPTION
so that they can handle/log them in a custom suitable way (instead of console.log)

Consider merging #18 instead and just closing this one.