### PR TITLE
Add options.metricReportedHook

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,12 @@ The ``options`` object accepts the following fields:
         </td>
   </tr>
   <tr>
+    <th>metricReportedHook</th>
+    <td>function</td>
+    <td><code>none</code></td>
+    <td>Function invoked with `(metric key, Metric)` after it has been reported - so that the user can f.ex. `.clear()` counters.</td>
+  </tr>
+  <tr>
     <th>precision</th>
     <td>string</td>
     <td><code>n</code></td>

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -42,6 +42,7 @@ var Reporter = function(options) {
   this.bufferSize = options.bufferSize || 0;
   this.previousValues = {};
   this.tagger = options.tagger || function () { return {}; };
+  this.metricReportedHook = options.metricReportedHook || function (key, metric) {};
 
   if (options.scheduleInterval) {
     this.start(options.scheduleInterval, true);
@@ -157,6 +158,9 @@ Reporter.prototype.report = function(useBuffer) {
       }
       var tags = objectAssign(this.tagger(key), this.tags);
       this._influx.addPoint(key, tags, timestamp, fields);
+
+      // Post-report hook so that the metric can be reset if needed etc.
+      this.metricReportedHook(key, this._report.getMetric(key));
     }
   }
   if ((this._influx.points.length > this.bufferSize && useBuffer) || !useBuffer) {


### PR DESCRIPTION
Add this hook invoked after a metric has been reported so that the user
may f.ex. `.clear()` counters (since InfluxDB should do the aggregation)

Consider merging #18 instead and just closing this one.