### PR TITLE
Add options.namer for custom metric names

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,13 @@ The ``options`` object accepts the following fields:
         </td>
   </tr>
   <tr>
+    <th>namer</th>
+    <td>function</td>
+    <td><code>identity</code></td>
+    <td>Function invoked with the metric key and expected to return the desired name of the metric in InfluxDB</code>
+        </td>
+  </tr>
+  <tr>
     <th>precision</th>
     <td>string</td>
     <td><code>n</code></td>

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -42,6 +42,7 @@ var Reporter = function(options) {
   this.bufferSize = options.bufferSize || 0;
   this.previousValues = {};
   this.tagger = options.tagger || function () { return {}; };
+  this.namer = options.namer || function (metricKey) { return metricKey; };
 
   if (options.scheduleInterval) {
     this.start(options.scheduleInterval, true);
@@ -156,7 +157,8 @@ Reporter.prototype.report = function(useBuffer) {
           continue;
       }
       var tags = objectAssign(this.tagger(key), this.tags);
-      this._influx.addPoint(key, tags, timestamp, fields);
+      var metricName = this.namer(key, tags);
+      this._influx.addPoint(metricName, tags, timestamp, fields);
     }
   }
   if ((this._influx.points.length > this.bufferSize && useBuffer) || !useBuffer) {


### PR DESCRIPTION
By default, we use the metric key as the name. However some clients may
have problems with metrics containing e.g. dots. This gives the user
the ability to derive the name in whatever formats he prefers based
on the key.

Consider merging #18 instead and just closing this one.