### PR TITLE
Default precision to `ms`, which we actually use

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ The ``options`` object accepts the following fields:
   <tr>
     <th>precision</th>
     <td>string</td>
-    <td><code>n</code></td>
+    <td><code>ms</code></td>
     <td><code>n</code>/<code>u</code>/<code>ms</code>/<code>s</code>/<code>m</code>/<code>h</code></td>
   </tr>
   <tr>

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -34,7 +34,9 @@ var objectAssign = (typeof Object.assign != 'function') ? function (target) {
 } : Object.assign;
 
 var Reporter = function(options) {
-  options = options || {}
+  options = options || {};
+  // Default precision to ms because that is what we are sending
+  options.precision = options.precision || 'ms';
   this._influx = new Influx(options);
   this._report = new Report(options.trackedMetrics);
   this.tags = options.tags || {};


### PR DESCRIPTION
(since new Date().getTime(), which we use for the timestamp, returns ms)

Fixes #20