### PR TITLE
Feature field filter

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -87,74 +87,80 @@ function canSkipMetric(reporter, name, value) {
   return reporter.skipIdleMetrics && isIdle;
 }
 
+Reporter.prototype._addField = function (key, metric, fields, fieldName, field) {
+  fields[fieldName] = field;
+  return fields;
+}
+
 Reporter.prototype.report = function(useBuffer) {
     var summary = this._report.summary();
     var timestamp = new Date().getTime();
 
     for (var namespace in summary) {
-        for (var metric in summary[namespace]) {
-            var key = namespace + '.' + metric;
+        for (var metricName in summary[namespace]) {
+            var key = namespace + '.' + metricName;
             var fields = {};
-            switch(summary[namespace][metric].type) {
+          var metric = summary[namespace][metricName];
+
+          switch(metric.type) {
                 case 'counter':
-                    if (canSkipMetric(this, key, summary[namespace][metric].count)) {
+                    if (canSkipMetric(this, key, metric.count)) {
                         continue;
                     }
-                    fields['count']          = { type: 'integer', value: summary[namespace][metric].count };
+                    this._addField(key, metric, fields, "count", {type: 'integer', value: metric.count});
                     break;
                 case 'meter':
-                    if (canSkipMetric(this, key, summary[namespace][metric].count)) {
+                    if (canSkipMetric(this, key, metric.count)) {
                         continue;
                     }
-                    fields['count']          = { type: 'integer', value: summary[namespace][metric].count };
-                    fields['one-minute']     = { type: 'float', value: summary[namespace][metric].m1 };
-                    fields['five-minute']    = { type: 'float', value: summary[namespace][metric].m5 };
-                    fields['fifteen-minute'] = { type: 'float', value: summary[namespace][metric].m15 };
-                    fields['mean-rate']      = { type: 'float', value: summary[namespace][metric].mean };
+                    this._addField(key, metric, fields, "count", {type: 'integer', value: metric.count});
+                    this._addField(key, metric, fields, "one-minute", {type: 'float', value: metric.m1});
+                    this._addField(key, metric, fields, "five-minute", {type: 'float', value: metric.m5});
+                    this._addField(key, metric, fields, "fifteen-minute", {type: 'float', value: metric.m15});
+                    this._addField(key, metric, fields, "mean-rate", {type: 'float', value: metric.mean});
                     break;
                 case 'histogram':
-                    if (canSkipMetric(this, key, summary[namespace][metric].count)) {
+                    if (canSkipMetric(this, key, metric.count)) {
                         continue;
                     }
-                    fields['count']          = { type: 'integer', value: summary[namespace][metric].count };
-                    fields['min']            = { type: 'integer', value: summary[namespace][metric].min };
-                    fields['max']            = { type: 'integer', value: summary[namespace][metric].max };
-                    fields['sum']            = { type: 'integer', value: summary[namespace][metric].sum };
-                    fields['mean']           = { type: 'float', value: summary[namespace][metric].mean };
-                    fields['variance']       = { type: 'float', value: summary[namespace][metric].variance };
-                    fields['std-dev']        = { type: 'float', value: summary[namespace][metric].std_dev };
-                    fields['median']         = { type: 'float', value: summary[namespace][metric].median };
-                    fields['75-percentile']  = { type: 'float', value: summary[namespace][metric].p75 };
-                    fields['95-percentile']  = { type: 'float', value: summary[namespace][metric].p95 };
-                    fields['99-percentile']  = { type: 'float', value: summary[namespace][metric].p99 };
-                    fields['999-percentile'] = { type: 'float', value: summary[namespace][metric].p999 };
+                    this._addField(key, metric, fields, "count", {type: 'integer', value: metric.count});
+                    this._addField(key, metric, fields, "min", {type: 'integer', value: metric.min});
+                    this._addField(key, metric, fields, "max", {type: 'integer', value: metric.max});
+                    this._addField(key, metric, fields, "sum", {type: 'integer', value: metric.sum});
+                    this._addField(key, metric, fields, "mean", {type: 'float', value: metric.mean});
+                    this._addField(key, metric, fields, "variance", {type: 'float', value: metric.variance});
+                    this._addField(key, metric, fields, "std-dev", {type: 'float', value: metric.std_dev});
+                    this._addField(key, metric, fields, "median", {type: 'float', value: metric.median});
+                    this._addField(key, metric, fields, "75-percentile", {type: 'float', value: metric.p75});
+                    this._addField(key, metric, fields, "95-percentile", {type: 'float', value: metric.p95});
+                    this._addField(key, metric, fields, "99-percentile", {type: 'float', value: metric.p99});
+                    this._addField(key, metric, fields, "999-percentile", {type: 'float', value: metric.p999});
                     break;
                 case 'timer':
-                    if (canSkipMetric(this, key, summary[namespace][metric].rate.count)) {
+                    if (canSkipMetric(this, key, metric.rate.count)) {
                         continue;
                     }
-                    fields['count']          = { type: 'integer', value: summary[namespace][metric].rate.count };
-                    fields['one-minute']     = { type: 'float', value: summary[namespace][metric].rate.m1 };
-                    fields['five-minute']    = { type: 'float', value: summary[namespace][metric].rate.m5 };
-                    fields['fifteen-minute'] = { type: 'float', value: summary[namespace][metric].rate.m15 };
-                    fields['mean-rate']      = { type: 'float', value: summary[namespace][metric].rate.mean };
-                    fields['min']            = { type: 'integer', value: summary[namespace][metric].duration.min };
-                    fields['max']            = { type: 'integer', value: summary[namespace][metric].duration.max };
-                    fields['sum']            = { type: 'integer', value: summary[namespace][metric].duration.sum };
-                    fields['mean']           = { type: 'float', value: summary[namespace][metric].duration.mean };
-                    fields['variance']       = { type: 'float', value: summary[namespace][metric].duration.variance };
-                    fields['std-dev']        = { type: 'float', value: summary[namespace][metric].duration.std_dev };
-                    fields['median']         = { type: 'float', value: summary[namespace][metric].duration.median };
-                    fields['75-percentile']  = { type: 'float', value: summary[namespace][metric].duration.p75 };
-                    fields['95-percentile']  = { type: 'float', value: summary[namespace][metric].duration.p95 };
-                    fields['99-percentile']  = { type: 'float', value: summary[namespace][metric].duration.p99 };
-                    fields['999-percentile'] = { type: 'float', value: summary[namespace][metric].duration.p999 };
+                    this._addField(key, metric, fields, "count", {type: 'integer', value: metric.rate.count});
+                    this._addField(key, metric, fields, "one-minute", {type: 'float', value: metric.rate.m1});
+                    this._addField(key, metric, fields, "five-minute", {type: 'float', value: metric.rate.m5});
+                    this._addField(key, metric, fields, "fifteen-minute", {type: 'float', value: metric.rate.m15});
+                    this._addField(key, metric, fields, "mean-rate", {type: 'float', value: metric.rate.mean});
+                    this._addField(key, metric, fields, "min", {type: 'integer', value: metric.duration.min});
+                    this._addField(key, metric, fields, "max", {type: 'integer', value: metric.duration.max});
+                    this._addField(key, metric, fields, "sum", {type: 'integer', value: metric.duration.sum});
+                    this._addField(key, metric, fields, "mean", {type: 'float', value: metric.duration.mean});
+                    this._addField(key, metric, fields, "variance", {type: 'float', value: metric.duration.variance});
+                    this._addField(key, metric, fields, "std-dev", {type: 'float', value: metric.duration.std_dev});
+                    this._addField(key, metric, fields, "median", {type: 'float', value: metric.duration.median});
+                    this._addField(key, metric, fields, "75-percentile", {type: 'float', value: metric.duration.p75});
+                    this._addField(key, metric, fields, "95-percentile", {type: 'float', value: metric.duration.p95});
+                    this._addField(key, metric, fields, "99-percentile", {type: 'float', value: metric.duration.p99});
+                    this._addField(key, metric, fields, "999-percentile", {type: 'float', value: metric.duration.p999});
                     break;
                 case 'gauge':
-                    var gaugeArray = summary[namespace][metric].points.splice(0, summary[namespace][metric].points.length);
+                    var gaugeArray = metric.points.splice(0, metric.points.length);
                     gaugeArray.forEach(function(gauge) {
-                        var gaugeFields = {};
-                        gaugeFields['count']   = { type: 'integer', value: gauge.value };
+                        var gaugeFields = this._addField(key, metric, {}, "count", {type: 'integer', value: gauge.value});
                         this.addPoint(key, gauge.timestamp, gaugeFields, gauge.tags);
                     }, this);
                     continue;

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -46,6 +46,7 @@ var Reporter = function(options) {
   this.tagger = options.tagger || function () { return {}; };
   this.namer = options.namer || function (metricKey) { return metricKey; };
   this.metricReportedHook = options.metricReportedHook || function (key, metric) {};
+  this.fieldFilter = options.fieldFilter || function (key, metric, fieldName, fieldValue) { return true; };
 
   if (options.scheduleInterval) {
     this.start(options.scheduleInterval, true);
@@ -88,7 +89,9 @@ function canSkipMetric(reporter, name, value) {
 }
 
 Reporter.prototype._addField = function (key, metric, fields, fieldName, field) {
-  fields[fieldName] = field;
+  if (this.fieldFilter(key, metric, fieldName, field.value)) {
+    fields[fieldName] = field;
+  }
   return fields;
 }
 
@@ -178,6 +181,8 @@ Reporter.prototype.report = function(useBuffer) {
 
 Reporter.prototype.addPoint = function (key, timestamp, fields, extraTags) {
 
+  if (isEmpty(fields)) return;
+
     // Skip invalid fields; e.g. a Timer's std-dev and variance are sometimes NaN
     for (var fieldName in fields) {
         if (fields.hasOwnProperty(fieldName)) {
@@ -202,6 +207,16 @@ Reporter.prototype.addMetric = function (){
 
 Reporter.prototype.getMetric = function (name){
   return this._report.getMetric(name);
+}
+
+function isEmpty(obj) {
+  for (var key in obj) {
+    if (obj.hasOwnProperty(key)) {
+      return false;
+    }
+  }
+
+  return true;
 }
 
 module.exports = Reporter;

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -137,10 +137,10 @@ Reporter.prototype.report = function(useBuffer) {
                     this._addField(key, metric, fields, "999-percentile", {type: 'float', value: metric.p999});
                     break;
                 case 'timer':
-                    if (canSkipMetric(this, key, metric.rate.count)) {
+                    if (canSkipMetric(this, key, metric.duration.count)) {
                         continue;
                     }
-                    this._addField(key, metric, fields, "count", {type: 'integer', value: metric.rate.count});
+                    this._addField(key, metric, fields, "count", {type: 'integer', value: metric.duration.count});
                     this._addField(key, metric, fields, "one-minute", {type: 'float', value: metric.rate.m1});
                     this._addField(key, metric, fields, "five-minute", {type: 'float', value: metric.rate.m5});
                     this._addField(key, metric, fields, "fifteen-minute", {type: 'float', value: metric.rate.m15});


### PR DESCRIPTION
Add the option `fieldFilter` to enable users to:

- decide which fields to send to InfluxDB 
- decide which values to send to InfluxDB

... and thus to save space in InfluxDB.

For example if you want InfluxDB, not `metrics`, to perform data aggregation than it is pointless to send percentiles.

Additionally, users may decide not to send 0s (that will be frequent if using Influx to aggregate and thus clearing all metrics after each send) and instead use Influx's `fill(0)`.

